### PR TITLE
Add support for Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,10 @@ Run the scripts in the following order:
 ./install-openrave.sh
 ```
 
-## Need to run!
+## Post-installation 
+If you have a segfault, place this line in .bashrc or .zshrc and try
+again.
+
+```bash
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib64
+```

--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ Run the scripts in the following order:
 ./install-fcl.sh
 ./install-openrave.sh
 ```
+
+## Need to run!
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib64

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -28,6 +28,8 @@ if [ $(lsb_release -sr) = '14.04' ]; then
   sudo apt-get install -y --no-install-recommends qt4-dev-tools zlib-bin
 elif [ $(lsb_release -sr) = '16.04' ]; then
   sudo apt-get install -y --no-install-recommends qt5-default minizip
+elif [ $(lsb_release -sr) = '18.04' ]; then
+  sudo apt-get install -y --no-install-recommends qt5-default minizip
 fi
 # Libraries
 sudo apt-get install -y --no-install-recommends ann-tools libann-dev          \
@@ -41,6 +43,9 @@ if [ $(lsb_release -sr) = '14.04' ]; then
   sudo apt-get install -y --no-install-recommends collada-dom-dev libccd      \
   libpcrecpp0 liblog4cxx10-dev libqt4-dev
 elif [ $(lsb_release -sr) = '16.04' ]; then
+  sudo apt-get install -y --no-install-recommends libccd-dev                  \
+  libcollada-dom2.4-dp-dev liblog4cxx-dev libminizip-dev octomap-tools
+elif [ $(lsb_release -sr) = '18.04' ]; then
   sudo apt-get install -y --no-install-recommends libccd-dev                  \
   libcollada-dom2.4-dp-dev liblog4cxx-dev libminizip-dev octomap-tools
 fi

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -34,18 +34,19 @@ fi
 # Libraries
 sudo apt-get install -y --no-install-recommends ann-tools libann-dev          \
 libassimp-dev libavcodec-dev libavformat-dev libboost-python-dev              \
-libboost-all-dev libeigen3-dev libfaac-dev libflann-dev libfreetype6-dev      \
+libeigen3-dev libfaac-dev libflann-dev libfreetype6-dev      \
 liblapack-dev libglew-dev libgsm1-dev libmpfi-dev  libmpfr-dev liboctave-dev  \
 libode-dev libogg-dev libpcre3-dev libqhull-dev  libsoqt-dev-common           \
 libsoqt4-dev libswscale-dev libtinyxml-dev libvorbis-dev  libx264-dev         \
 libxml2-dev libxvidcore-dev
 if [ $(lsb_release -sr) = '14.04' ]; then
   sudo apt-get install -y --no-install-recommends collada-dom-dev libccd      \
-  libpcrecpp0 liblog4cxx10-dev libqt4-dev
+  libpcrecpp0 liblog4cxx10-dev libqt4-dev libboost-all-dev 
 elif [ $(lsb_release -sr) = '16.04' ]; then
   sudo apt-get install -y --no-install-recommends libccd-dev                  \
-  libcollada-dom2.4-dp-dev liblog4cxx-dev libminizip-dev octomap-tools
+  libcollada-dom2.4-dp-dev liblog4cxx-dev libminizip-dev octomap-tools libboost-all-dev 
 elif [ $(lsb_release -sr) = '18.04' ]; then
   sudo apt-get install -y --no-install-recommends libccd-dev                  \
-  libcollada-dom2.4-dp-dev liblog4cxx-dev libminizip-dev octomap-tools
+  libcollada-dom2.4-dp-dev liblog4cxx-dev libminizip-dev octomap-tools  \
+  libboost1.62-all-dev 
 fi

--- a/install-openrave.sh
+++ b/install-openrave.sh
@@ -21,6 +21,6 @@ mkdir -p ~/git; cd ~/git
 git clone https://github.com/rdiankov/openrave.git
 cd openrave; git reset --hard $COMMIT
 mkdir build; cd build
-cmake -DODE_USE_MULTITHREAD=ON -DOSG_DIR=/usr/local/lib64/  -DCMAKE_CXX_STANDARD=11 ..
+cmake -DODE_USE_MULTITHREAD=ON -DOSG_DIR=/usr/local/lib64/ -DCMAKE_CXX_STANDARD=11 ..
 make -j `nproc`
 sudo make install

--- a/install-openrave.sh
+++ b/install-openrave.sh
@@ -13,7 +13,7 @@ echo ""
 pip install --upgrade --user sympy==0.7.1
 
 # OpenRAVE
-COMMIT=9350ebc
+COMMIT=7c5f5e2
 echo ""
 echo "Installing OpenRAVE 0.9 from source (Commit $COMMIT)..."
 echo ""
@@ -21,6 +21,6 @@ mkdir -p ~/git; cd ~/git
 git clone https://github.com/rdiankov/openrave.git
 cd openrave; git reset --hard $COMMIT
 mkdir build; cd build
-cmake -DODE_USE_MULTITHREAD=ON -DOSG_DIR=/usr/local/lib64/ ..
+cmake -DODE_USE_MULTITHREAD=ON -DOSG_DIR=/usr/local/lib64/  -DCMAKE_CXX_STANDARD=11 ..
 make -j `nproc`
 sudo make install

--- a/install-osg.sh
+++ b/install-osg.sh
@@ -19,7 +19,7 @@ if [ $(lsb_release -sr) = '14.04' ]; then
 elif [ $(lsb_release -sr) = '16.04' ]; then
   cmake .. -DDESIRED_QT_VERSION=4
 elif [ $(lsb_release -sr) = '18.04' ]; then
-  cmake -DDESIRED_QT_VERSION=4 ..
+  cmake .. -DDESIRED_QT_VERSION=4 
 fi
 make -j `nproc`
 sudo make install

--- a/install-osg.sh
+++ b/install-osg.sh
@@ -18,6 +18,8 @@ if [ $(lsb_release -sr) = '14.04' ]; then
   cmake ..
 elif [ $(lsb_release -sr) = '16.04' ]; then
   cmake .. -DDESIRED_QT_VERSION=4
+elif [ $(lsb_release -sr) = '18.04' ]; then
+  cmake .. -DDESIRED_QT_VERSION=4
 fi
 make -j `nproc`
 sudo make install

--- a/install-osg.sh
+++ b/install-osg.sh
@@ -19,7 +19,7 @@ if [ $(lsb_release -sr) = '14.04' ]; then
 elif [ $(lsb_release -sr) = '16.04' ]; then
   cmake .. -DDESIRED_QT_VERSION=4
 elif [ $(lsb_release -sr) = '18.04' ]; then
-  cmake .. -DDESIRED_QT_VERSION=4
+  cmake -DDESIRED_QT_VERSION=4 ..
 fi
 make -j `nproc`
 sudo make install


### PR DESCRIPTION
- install boost 1.62 instead of 1.65. The latter causes conflict with openrave's Python binding;
- some other minor fixes.