### PR TITLE
Add missing dependencies:

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -31,7 +31,7 @@ sudo apt-get update
 # Programs
 sudo apt-get install -y --no-install-recommends build-essential cmake doxygen   \
 g++ git ipython octave python-dev python-h5py python-numpy python-pip           \
-python-scipy python-setuptools python-wheel
+python-scipy python-setuptools python-wheel wget mlocate
 if [ ${UBUNTU_VER} = '14.04' ]; then
   sudo apt-get install -y --no-install-recommends qt4-dev-tools zlib-bin
 elif [ ${UBUNTU_VER} = '16.04' ] || [ ${UBUNTU_VER} = '18.04' ]; then


### PR DESCRIPTION
Added missing dependencies:
- wget
- mlocate (updatedb)

These were missing when I tried to install openrave on top of `nvidia/opengl:1.0-glvnd-runtime-ubuntu18.04` docker image