### PR TITLE
Upgrade openrave for ubuntu 18.04:

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -70,21 +70,12 @@ elif [ ${UBUNTU_VER} = '16.04' ] || [ ${UBUNTU_VER} = '18.04' ] || [ ${UBUNTU_VE
 fi
 
 # Install boost
-if [ ${UBUNTU_VER} = '14.04' ] || [ ${UBUNTU_VER} = '16.04' ] || [ ${UBUNTU_VER} = '20.04' ]; then
-    sudo apt-get install -y --no-install-recommends libboost-all-dev libboost-python-dev
-elif [ ${UBUNTU_VER} = '18.04' ]; then
-    # Install boost 1.58 from source
-    BOOST_SRC_DIR=~/git/boost_1_58_0
-    mkdir -p ~/git; cd ~/git
-    wget http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz -O ${BOOST_SRC_DIR}.tar.gz
-    tar -xzf ${BOOST_SRC_DIR}.tar.gz
-    cd ${BOOST_SRC_DIR}
-    ./bootstrap.sh --exec-prefix=/usr/local
-    ./b2 -j `nproc`
-    sudo ./b2 -j `nproc` install threading=multi
-fi
+sudo apt-get install -y --no-install-recommends libboost-all-dev libboost-python-dev
 
-if [ ${UBUNTU_VER} = '20.04' ]; then
+if [ ${UBUNTU_VER} = '18.04' ] || [ ${UBUNTU_VER} = '20.04' ]; then
+  # Install opengl
+  pip install pyopengl
+
   # Install RapidJSON
   mkdir -p ~/git 
   cd ~/git && git clone https://github.com/Tencent/rapidjson.git
@@ -92,10 +83,12 @@ if [ ${UBUNTU_VER} = '20.04' ]; then
   cmake .. && make -j `nproc` && sudo make install
 
   # Install Pybind
-  cd ~/git && git clone https://github.com/pybind/pybind11.git
-  cd pybind11 
+  cd ~/git && git clone https://github.com/pybind/pybind11.git 
+  cd pybind11
+  # Set Git credentials to allow git cherry-pick
   git config --local user.name crigroup
   git config --local user.email crigroup@example.com
+  echo "Random Git credentials set as: crigroup (username) and crigroup@example.com (email)"
   mkdir build && cd build 
   git remote add woody https://github.com/woodychow/pybind11.git \
     && git remote add cielavenir https://github.com/cielavenir/pybind11.git \

--- a/install-openrave.sh
+++ b/install-openrave.sh
@@ -22,17 +22,17 @@ echo ""
 pip install --upgrade --user sympy==0.7.1
 
 # OpenRAVE
-if [ ${UBUNTU_VER} = '14.04' ] || [ ${UBUNTU_VER} = '16.04' ] || [ ${UBUNTU_VER} = '18.04' ]; then
+if [ ${UBUNTU_VER} = '14.04' ] || [ ${UBUNTU_VER} = '16.04' ]; then
 	RAVE_COMMIT=7c5f5e27eec2b2ef10aa63fbc519a998c276f908
 	echo ""
 	echo "Installing OpenRAVE 0.9 from source (Commit ${RAVE_COMMIT})..."
 	echo ""
 	mkdir -p ~/git; cd ~/git
 	git clone https://github.com/rdiankov/openrave.git
-elif [ ${UBUNTU_VER} = '20.04' ]; then
+elif [ ${UBUNTU_VER} = '18.04' ] || [ ${UBUNTU_VER} = '20.04' ]; then
 	RAVE_COMMIT=2024b03554c8dd0e82ec1c48ae1eb6ed37d0aa6e
 	echo ""
-	echo "Installing OpenRAVE 0.53 from source (Commit ${RAVE_COMMIT})..."
+	echo "Installing OpenRAVE 0.53.1 from source (Commit ${RAVE_COMMIT})..."
 	echo ""
 	mkdir -p ~/git; cd ~/git
 	git clone -b production https://github.com/rdiankov/openrave.git
@@ -41,10 +41,7 @@ cd openrave; git reset --hard ${RAVE_COMMIT}
 mkdir build; cd build
 if [ ${UBUNTU_VER} = '14.04' ] || [ ${UBUNTU_VER} = '16.04' ]; then
   	cmake -DODE_USE_MULTITHREAD=ON -DOSG_DIR=/usr/local/lib64/ ..
-elif [ ${UBUNTU_VER} = '18.04' ]; then
-  	cmake -DODE_USE_MULTITHREAD=ON -DCMAKE_CXX_STANDARD=11            \
-  		-DBoost_NO_SYSTEM_PATHS=TRUE -DBOOST_ROOT=/usr/local/ ..
-elif [ ${UBUNTU_VER} = '20.04' ]; then
+elif [ ${UBUNTU_VER} = '18.04' ] || [ ${UBUNTU_VER} = '20.04' ]; then
   	cmake -DODE_USE_MULTITHREAD=ON -DOSG_DIR=/usr/local/lib64/ \
   		-DUSE_PYBIND11_PYTHON_BINDINGS:BOOL=TRUE 			   \
   		-DBoost_NO_BOOST_CMAKE=1 ..


### PR DESCRIPTION
- Compiles with pybind instead of downgrading boost
- Add git credentials check, set to a placeholder if none
- Add pyopengl installation
- OpenRAVE v0.53.1