### PR TITLE
Fix ubuntu 20.04 installation

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -41,7 +41,7 @@ elif [ ${UBUNTU_VER} = '20.04' ]; then
   sudo apt-get install -y --no-install-recommends python2 curl
   curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
   sudo python2 get-pip.py
-  pip install ipython h5py numpy scipy wheel pyopengl
+  pip install ipython h5py numpy scipy wheel
 fi
 if [ ${UBUNTU_VER} = '14.04' ]; then
   sudo apt-get install -y --no-install-recommends qt4-dev-tools zlib-bin
@@ -74,13 +74,13 @@ sudo apt-get install -y --no-install-recommends libboost-all-dev libboost-python
 
 if [ ${UBUNTU_VER} = '18.04' ] || [ ${UBUNTU_VER} = '20.04' ]; then
   # Install opengl
-  pip install pyopengl
+  pip install "pyopengl==3.1.6"
 
   # Install RapidJSON
   mkdir -p ~/git 
   cd ~/git && git clone https://github.com/Tencent/rapidjson.git
   cd rapidjson && mkdir build && cd build
-  cmake .. && make -j `nproc` && sudo make install
+  cmake -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF .. && make -j `nproc` && sudo make install
 
   # Install Pybind
   cd ~/git && git clone https://github.com/pybind/pybind11.git 


### PR DESCRIPTION
This should fix the recent issues (#31, #33) with the ubuntu 20.04 installation.

The issues were caused by updates on upstream dependencies:
- [rapidjson failing to build tests](https://github.com/Tencent/rapidjson/issues/2318) -> fixed by not building them on the installation script (they are not needed here anyway)
- a [pyopengl version released on May 2023](https://pypi.org/project/PyOpenGL/3.1.7/), which is failing to install on python 2.7 -> fixed by pinning the package to the anterior version.